### PR TITLE
Fix Query::Result not jumping to following pages while iterating

### DIFF
--- a/lib/odata/query/result.rb
+++ b/lib/odata/query/result.rb
@@ -19,7 +19,7 @@ module OData
       def each(&block)
         process_results(&block)
         until next_page.nil?
-          result = service.execute(next_page_url)
+          @result = service.execute(next_page_url)
           process_results(&block)
         end
       end


### PR DESCRIPTION
If found this small issue while iterating through a large collection
