### PR TITLE
Use entity set name as the key for Service#entity_sets hash

### DIFF
--- a/lib/odata/service.rb
+++ b/lib/odata/service.rb
@@ -45,8 +45,8 @@ module OData
     def entity_sets
       @entity_sets ||= Hash[metadata.xpath('//EntityContainer/EntitySet').collect {|entity|
         [
-          entity.attributes['EntityType'].value.gsub("#{namespace}.", ''),
-          entity.attributes['Name'].value
+          entity.attributes['Name'].value,
+          entity.attributes['EntityType'].value.gsub("#{namespace}.", '')
         ]
       }]
     end

--- a/spec/odata/service_spec.rb
+++ b/spec/odata/service_spec.rb
@@ -46,8 +46,8 @@ describe OData::Service, vcr: {cassette_name: 'service_specs'} do
 
   describe '#entity_sets' do
     it { expect(subject.entity_sets.size).to eq(7) }
-    it { expect(subject.entity_sets.keys).to eq(entity_set_types) }
-    it { expect(subject.entity_sets.values).to eq(entity_sets) }
+    it { expect(subject.entity_sets.keys).to eq(entity_sets) }
+    it { expect(subject.entity_sets.values).to eq(entity_set_types) }
   end
 
   describe '#complex_types' do


### PR DESCRIPTION
I think it makes more sense to use the name of the entity sets as the key for this hash. Otherwise, it will fail when there is more than one entity set with the same type.
