### PR TITLE
Update result.rb to remove useless variable assignment

### DIFF
--- a/lib/odata/query/result.rb
+++ b/lib/odata/query/result.rb
@@ -19,7 +19,7 @@ module OData
       def each(&block)
         process_results(&block)
         until next_page.nil?
-          result = service.execute(next_page_url)
+          service.execute(next_page_url)
           process_results(&block)
         end
       end


### PR DESCRIPTION
Useless assignment to variable - `result`, unless I missed something.
