### PR TITLE
Added lazy loading to OData entity properties. Entity property will be loaded only when requested

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,18 @@ For example using **ntlm** authentication:
 For more authentication options see [libcurl](http://curl.haxx.se/libcurl/c/CURLOPT_HTTPAUTH.html) or
 [typhoeus](https://github.com/typhoeus/typhoeus).
 
+### Metadata File
+
+Typically the metadata file of a service can be quite large. You can speed your load 
+time by forcing the service to load the metadata from a file rather than a URL.
+This is only recommended for testing purposes, as the metadata file can change.
+
+    conn = OData::Service.open('http://services.odata.org/OData/OData.svc', {
+        name: 'ODataDemo',
+        metadata_file: "metadata.xml",
+    })
+
+
 ### Headers
 
 You can set the headers with the **:typhoeus** param like so:
@@ -168,6 +180,27 @@ ready to save back to the service or `OData::EntitySet`, which you do like so:
 You can get a list of all your entities like this:
 
     svc.entity_types
+    
+#### Entity Properties
+Reading, parsing and instantiating all properties of an entity can add up to a 
+significant amount of time, particularly for those entities with a large number
+of properties. To speed this process up all properties are lazy loaded. Which means
+it will store the name of the property, but will not parse and instantiate the 
+property until you want to use it.
+ 
+You can find all the property names of your entity with
+ 
+    product.property_names
+    
+When you want to grab the value of the property like this
+
+    product["Name"]
+    
+    or
+    
+    product.get_property("Name")
+    
+It will parse and instantiate the property if it hasnt done so yet.
 
 ### Queries
 

--- a/spec/fixtures/vcr_cassettes/query_specs.yml
+++ b/spec/fixtures/vcr_cassettes/query_specs.yml
@@ -579,4 +579,128 @@ http_interactions:
     adapter_metadata:
       effective_url: http://services.odata.org/OData/OData.svc/Products/$count?$filter=Name%20eq%20'NonExistent'
   recorded_at: Fri, 10 Oct 2014 20:21:36 GMT
-recorded_with: VCR 2.9.2
+- request:
+    method: get
+    uri: http://services.odata.org/OData/OData.svc/Products/$count?$filter=Name%20eq%20Bread
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Typhoeus - https://github.com/typhoeus/typhoeus
+      DataServiceVersion:
+      - '3.0'
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '1611'
+      Content-Type:
+      - application/xml;charset=utf-8
+      Server:
+      - Microsoft-IIS/8.0
+      X-Content-Type-Options:
+      - nosniff
+      DataServiceVersion:
+      - 1.0;
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Allow-Headers:
+      - Accept, Origin, Content-Type, MaxDataServiceVersion
+      Access-Control-Expose-Headers:
+      - DataServiceVersion
+      Set-Cookie:
+      - ARRAffinity=b1399c8672c5f524fd7bdda0a48adededda0ab63f6956750aa2e9a3df719db91;Path=/;Domain=services.odata.org
+      Date:
+      - Tue, 28 Apr 2015 20:26:58 GMT
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="utf-8"?><m:error xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"><m:code /><m:message xml:lang="en-US">Could not find a property named 'Bread' on type 'ODataDemo.Product'.</m:message><m:innererror><m:message>Could not find a property named 'Bread' on type 'ODataDemo.Product'.</m:message><m:type>Microsoft.Data.OData.ODataException</m:type><m:stacktrace>   at Microsoft.Data.OData.Query.EndPathBinder.GeneratePropertyAccessQueryForOpenType(EndPathToken endPathToken, SingleValueNode parentNode)&#xD;
+           at Microsoft.Data.OData.Query.EndPathBinder.BindEndPath(EndPathToken endPathToken, BindingState state)&#xD;
+           at Microsoft.Data.OData.Query.MetadataBinder.BindEndPath(EndPathToken endPathToken)&#xD;
+           at Microsoft.Data.OData.Query.MetadataBinder.Bind(QueryToken token)&#xD;
+           at Microsoft.Data.OData.Query.BinaryOperatorBinder.GetOperandFromToken(BinaryOperatorKind operatorKind, QueryToken queryToken)&#xD;
+           at Microsoft.Data.OData.Query.BinaryOperatorBinder.BindBinaryOperator(BinaryOperatorToken binaryOperatorToken)&#xD;
+           at Microsoft.Data.OData.Query.MetadataBinder.BindBinaryOperator(BinaryOperatorToken binaryOperatorToken)&#xD;
+           at Microsoft.Data.OData.Query.MetadataBinder.Bind(QueryToken token)&#xD;
+           at Microsoft.Data.OData.Query.FilterBinder.BindFilter(QueryToken filter)&#xD;
+           at Microsoft.Data.OData.Query.ODataUriParser.ParseFilterImplementation(String filter, IEdmType elementType, IEdmEntitySet entitySet)&#xD;
+           at System.Data.Services.Parsing.RequestExpressionParser.ParseFilter()</m:stacktrace></m:innererror></m:error>
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: http://services.odata.org/OData/OData.svc/Products/$count?$filter=Name%20eq%20Bread
+  recorded_at: Tue, 28 Apr 2015 20:26:59 GMT
+- request:
+    method: get
+    uri: http://services.odata.org/OData/OData.svc/Products/$count?$filter=Name%20eq%20NonExistent
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      User-Agent:
+      - Typhoeus - https://github.com/typhoeus/typhoeus
+      DataServiceVersion:
+      - '3.0'
+  response:
+    status:
+      code: 400
+      message: Bad Request
+    headers:
+      Cache-Control:
+      - private
+      Content-Length:
+      - '1623'
+      Content-Type:
+      - application/xml;charset=utf-8
+      Server:
+      - Microsoft-IIS/8.0
+      X-Content-Type-Options:
+      - nosniff
+      DataServiceVersion:
+      - 1.0;
+      X-AspNet-Version:
+      - 4.0.30319
+      X-Powered-By:
+      - ASP.NET
+      Access-Control-Allow-Origin:
+      - "*"
+      Access-Control-Allow-Methods:
+      - GET
+      Access-Control-Allow-Headers:
+      - Accept, Origin, Content-Type, MaxDataServiceVersion
+      Access-Control-Expose-Headers:
+      - DataServiceVersion
+      Set-Cookie:
+      - ARRAffinity=b1399c8672c5f524fd7bdda0a48adededda0ab63f6956750aa2e9a3df719db91;Path=/;Domain=services.odata.org
+      Date:
+      - Tue, 28 Apr 2015 20:26:58 GMT
+    body:
+      encoding: UTF-8
+      string: |-
+        <?xml version="1.0" encoding="utf-8"?><m:error xmlns:m="http://schemas.microsoft.com/ado/2007/08/dataservices/metadata"><m:code /><m:message xml:lang="en-US">Could not find a property named 'NonExistent' on type 'ODataDemo.Product'.</m:message><m:innererror><m:message>Could not find a property named 'NonExistent' on type 'ODataDemo.Product'.</m:message><m:type>Microsoft.Data.OData.ODataException</m:type><m:stacktrace>   at Microsoft.Data.OData.Query.EndPathBinder.GeneratePropertyAccessQueryForOpenType(EndPathToken endPathToken, SingleValueNode parentNode)&#xD;
+           at Microsoft.Data.OData.Query.EndPathBinder.BindEndPath(EndPathToken endPathToken, BindingState state)&#xD;
+           at Microsoft.Data.OData.Query.MetadataBinder.BindEndPath(EndPathToken endPathToken)&#xD;
+           at Microsoft.Data.OData.Query.MetadataBinder.Bind(QueryToken token)&#xD;
+           at Microsoft.Data.OData.Query.BinaryOperatorBinder.GetOperandFromToken(BinaryOperatorKind operatorKind, QueryToken queryToken)&#xD;
+           at Microsoft.Data.OData.Query.BinaryOperatorBinder.BindBinaryOperator(BinaryOperatorToken binaryOperatorToken)&#xD;
+           at Microsoft.Data.OData.Query.MetadataBinder.BindBinaryOperator(BinaryOperatorToken binaryOperatorToken)&#xD;
+           at Microsoft.Data.OData.Query.MetadataBinder.Bind(QueryToken token)&#xD;
+           at Microsoft.Data.OData.Query.FilterBinder.BindFilter(QueryToken filter)&#xD;
+           at Microsoft.Data.OData.Query.ODataUriParser.ParseFilterImplementation(String filter, IEdmType elementType, IEdmEntitySet entitySet)&#xD;
+           at System.Data.Services.Parsing.RequestExpressionParser.ParseFilter()</m:stacktrace></m:innererror></m:error>
+    http_version: '1.1'
+    adapter_metadata:
+      effective_url: http://services.odata.org/OData/OData.svc/Products/$count?$filter=Name%20eq%20NonExistent
+  recorded_at: Tue, 28 Apr 2015 20:26:59 GMT
+recorded_with: VCR 2.9.3

--- a/spec/odata/query_spec.rb
+++ b/spec/odata/query_spec.rb
@@ -18,7 +18,7 @@ describe OData::Query, vcr: {cassette_name: 'query_specs'} do
   it { expect(subject).to respond_to(:[]) }
   describe '#[]' do
     it { expect(subject[:Name]).to be_a(OData::Query::Criteria) }
-    it { expect(subject[:Name].property).to be_a(OData::Property) }
+    it { puts "Subject[:Name].property=#{subject[:Name].property} class=#{subject[:Name].property.class}"; puts "Subject=#{subject.inspect}"; expect(subject[:Name].property).to be_a(OData::Property) }
   end
 
   it { expect(subject).to respond_to(:where) }


### PR DESCRIPTION
Lazy loading added to Entity properties so performance increases. Entity property only loaded when requested.

I did not test create yet, and I dont think update or delete is implemeted yet.